### PR TITLE
streamlined installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,9 @@ If you have used **ResFinder + Reference Gene Catalog + CARD** or **Tool 2 and/o
 ## Dependencies
 
 - Python 3.9.5
+- pandas 2.2+
 - BLAST+ : 2.9.0+
-- Biopython : 1.84
+- Biopython : 1.84+
 - All the installed packages are available in the installed_packages.txt
 
   

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ AmrProfiler relies on the RefSeq database (downloaded on 01/06/2025). It is impl
 
 To run AmrProfiler locally, you must first download the required databases and files from Zenodo (https://zenodo.org/records/15674467). Extract the downloaded folders inside the `amrprofiler` directory from this repo.
 
+After this, install the dependencies using `conda` and activate the newly created environment
+
+```bash
+conda env create -f ./amrprofiler-main/environment.yml
+conda activate amrprofiler
+```
+
+This is highly recommended as it will guarantee that `python v3.9.5` is installed properly.
+
 ## Running AmrProfiler
 
 ### Default Execution

--- a/environment.yml
+++ b/environment.yml
@@ -3,9 +3,9 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - blast
-  - pandas
-  - pip >= 25.0
+  - blast >=2.9
+  - pandas >=2.2
+  - pip >=25.0
   - python =3.9.5
   - pip:
-    - biopython
+    - biopython >=1.84

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,11 @@
+name: amrprofiler
+channels:
+  - bioconda
+  - conda-forge
+dependencies:
+  - blast
+  - pandas
+  - pip >= 25.0
+  - python =3.9.5
+  - pip:
+    - biopython


### PR DESCRIPTION
i have added a `conda` environment file and instructions on how to use it to get all the dependencies installed. this should significantly reduce the time a user needs to debug their installation of `amrprofiler`